### PR TITLE
use unwrap instead of match for better error reporting

### DIFF
--- a/syncre_lib/src/tests.rs
+++ b/syncre_lib/src/tests.rs
@@ -9,10 +9,8 @@ fn coping_test() {
     let simple_file = Path::new("testfiles/hello-world.txt");
     let dir: PathBuf = testdir!();
     let to = dir.join("hello-world.txt");
-    match archive::copy_sync(simple_file, to.as_path()) {
-        Err(e) => panic!("{}", e),
-        _ => {}
-    }
+
+    archive::copy_sync(simple_file, to.as_path()).unwrap();
 }
 
 #[test]
@@ -20,10 +18,8 @@ fn coping_symbolic_link_test() {
     let file_with_symbolic_link = Path::new("testfiles/link-hello.txt");
     let dir: PathBuf = testdir!();
     let to = dir.join("link-hello.txt");
-    match archive::copy_sync(file_with_symbolic_link, to.as_path()) {
-        Err(e) => panic!("{}", e),
-        _ => {}
-    }
+
+    archive::copy_sync(file_with_symbolic_link, to.as_path()).unwrap();
 }
 
 #[test]
@@ -31,10 +27,8 @@ fn coping_directory_test() {
     let directory = Path::new("testfiles/linked");
     let dir: PathBuf = testdir!();
     let to = dir.join("linked");
-    match archive::copy_sync(directory, to.as_path()) {
-        Err(e) => panic!("{}", e),
-        _ => {}
-    }
+
+    archive::copy_sync(directory, to.as_path()).unwrap();
 }
 
 // comment for erros in tests (from algorithm.rs)


### PR DESCRIPTION
ventajas:

* el código es más corto
* si el test falla, el mensaje de error es potencialmente más claro, porque es directo
* no hay por qué temerle al unwrap, mucho menos en tests ;)